### PR TITLE
[FE] 상세 페이지 이미지 늦게 렌더링 및 이미지 1장시 캐러셀 미노출

### DIFF
--- a/features/post/components/PostDetailImages.tsx
+++ b/features/post/components/PostDetailImages.tsx
@@ -24,6 +24,7 @@ function PostDetailImages(props: PostDetailImagesProps) {
 					fill
 					src={images[0].imageUrl}
 					alt="Post image"
+					priority
 					sizes="100vw"
 					className="object-cover"
 				/>
@@ -34,13 +35,14 @@ function PostDetailImages(props: PostDetailImagesProps) {
 	return (
 		<Carousel showDots>
 			<CarouselContent>
-				{images.map((image) => (
+				{images.map((image, index) => (
 					<CarouselItem key={image.postImageId} className="pl-0">
 						<div className="relative w-full aspect-square">
 							<Image
 								fill
 								src={image.imageUrl}
 								alt={`Post image`}
+								priority={index === 0}
 								sizes="100vw"
 								className="object-cover"
 							/>


### PR DESCRIPTION
## 📍 TO-BE
<!--  
PR 머지 후 달라지는 상태를 명확하게 적어주세요.  
예: "검색 페이지에서 검색어 입력 시 debounce 적용"  
-->

- 상세페이지 최초 이미지 렌더링 우선순위 높임
- 사진 1장일 경우 캐러셀 미노출

---

## 📝 변경 내용
<!-- 주요 변경사항을 bullet로 요약해서 적어주세요 -->

- 

---

## 🔧 작업 상세 내용
<!-- 선택: 상세 구현 설명, 흐름, 로직 변경 이유 -->

- 

---

## 🖼️ (Option) 이미지 / 스크린샷
<!-- UI 변경이 있을 경우 첨부 -->

| Before | After |
|--------|--------|
|  |  |

---

## ✅ 체크리스트
- [x] 기능 동작을 직접 테스트함
- [x] 에러/예외 케이스도 확인함
- [x] UI 변경 시 모바일/데스크탑 둘 다 확인함
- [ ] 관련 문서 또는 주석 업데이트함 (선택)

---

## 🔗 관련 이슈
<!-- 예: Closes #123 -->
Closes #121 
